### PR TITLE
Fix for fuzzylogic if WOA is missing in a location

### DIFF
--- a/cotede/qctests/woa_normbias.py
+++ b/cotede/qctests/woa_normbias.py
@@ -76,7 +76,7 @@ def woa_normbias(data, v, cfg):
         # self.logger.warn("%s - WOA is not available at this site" %
         # self.name)
         flag = np.zeros(data[v].shape, dtype='i1')
-        return flag, {}
+        return flag, {'woa_normbias': np.zeros(data[v].shape)}
 
     woa_bias = data[v] - woa['mn']
     woa_normbias = woa_bias/woa['sd']


### PR DESCRIPTION
The fuzzy logic QC test requires the woa_normbias entry in the features dictionary but this is not present if woa is None or the data are missing, which I think can then trigger a failure. This is an attempt to fix this.