### PR TITLE
WIP: contributing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ nosetests.xml
 .project
 .pydevproject
 
+# jetbrains
+.idea
+
 .*.swp
 *.hdf
 .cache

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,6 +67,7 @@ Ready to contribute? Here's how to set up `cotede` for local development.
     $ mkvirtualenv cotede
     $ cd cotede/
     $ python setup.py develop
+    $ pip install -r test-requirements.txt
 
 4. Create a branch for local development::
 
@@ -76,11 +77,9 @@ Ready to contribute? Here's how to set up `cotede` for local development.
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 cotede tests
+    $ py.test cotede --flake8 -m flake8
     $ py.test tests
     $ tox
-
-   To get flake8 and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 wheel>=0.23
 pytest>=4.4
+pytest-flake8
 pytest-xdist>=1.29
 pandas
 netCDF4


### PR DESCRIPTION
Updates to docs for contributing.

FWIW, I use conda instead of virtualenv. So I was able to set up with

```
conda create -y -n cotede37 python=3.7
conda activate cotede37
```

instead of `mkvirtualenv cotede`. 

After that, all steps were the same.

flake8 was not in the requirements list anywhere, so I added that to `test-requirements.txt` and added a step to install the libs in that file.

I was able to run the tests described:

```
$ flake8 cotede tests
$ py.test tests
$ tox
```

However there are a lot of flake8 failures. I recommend resolving those and/or adding a list of ignored tests to `flake8-ignore`. Otherwise, as a contributor I'd just ignore this.

Ref: https://github.com/openjournals/joss-reviews/issues/2063