### PR TITLE
guess at re-enabling density inversion

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors
 
 * Luiz Irber <luiz.irber@gmail.com>  
 * @lidong74; Reported bug #37, outdated notebook on fuzzy logic.
+* @BillMills: PR #47, re-introduce Argo density inversion as inherited QCCheck.

--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -246,7 +246,11 @@ class ProfileQC(object):
 
         for criterion in [c for c in catalog if c in cfg]:
             Procedure = catalog[criterion]
-            y = Procedure(self.input, v, cfg[criterion], autoflag=True)
+            try:
+                y = Procedure(self.input, v, cfg[criterion], autoflag=True)
+            except:
+                # currently accommodates catalog['density_inversion']
+                y = Procedure(self.input, cfg[criterion], autoflag=True)
 
             if self.saveauxiliary:
                 for f in y.features.keys():

--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -241,6 +241,7 @@ class ProfileQC(object):
                 'stuck_value': StuckValue,
                 'tukey53H_norm': Tukey53H,
                 'woa_normbias': WOA_NormBias,
+                'density_inversion': DensityInversion,
                 }
 
         for criterion in [c for c in catalog if c in cfg]:

--- a/cotede/qctests/density_inversion.py
+++ b/cotede/qctests/density_inversion.py
@@ -10,7 +10,7 @@ import logging
 import numpy as np
 from numpy import ma
 
-from .qctests import QCCheck
+from .qctests import QCCheckVar
 
 module_logger = logging.getLogger(__name__)
 
@@ -45,18 +45,7 @@ def densitystep(S, T, P, auto_rotate=False):
     return ma.fix_invalid(ds)
 
 
-class DensityInversion(QCCheck):
-    def __init__(self, data, cfg, autoflag=True):
-        assert "TEMP" in data.keys(), "Missing TEMP"
-        assert "PSAL" in data.keys(), "Missing PSAL"
-        assert "PRES" in data.keys(), "Missing PRES"
-
-        self.data = data
-        self.cfg = cfg
-
-        self.set_features()
-        if autoflag:
-            self.test()
+class DensityInversion(QCCheckVar):
 
     def set_features(self):
         self.features = {

--- a/cotede/qctests/density_inversion.py
+++ b/cotede/qctests/density_inversion.py
@@ -10,7 +10,7 @@ import logging
 import numpy as np
 from numpy import ma
 
-from .qctests import QCCheckVar
+from .qctests import QCCheck
 
 module_logger = logging.getLogger(__name__)
 
@@ -45,7 +45,13 @@ def densitystep(S, T, P, auto_rotate=False):
     return ma.fix_invalid(ds)
 
 
-class DensityInversion(QCCheckVar):
+class DensityInversion(QCCheck):
+    def __init__(self, data, cfg, autoflag=True):
+        assert "TEMP" in data.keys(), "Missing TEMP"
+        assert "PSAL" in data.keys(), "Missing PSAL"
+        assert "PRES" in data.keys(), "Missing PRES"
+
+        super().__init__(data=data, cfg=cfg, autoflag=autoflag)
 
     def set_features(self):
         self.features = {


### PR DESCRIPTION
Hi @castelao - per my comments in https://github.com/IQuOD/AutoQC/pull/259#issuecomment-711052578, I'm not sure how to run an Argo density inversion test since the case was removed in CoTeDe commit https://github.com/castelao/CoTeDe/commit/6f26a23974201df25dc15001dbf1ac6885e7cbe0. In this PR I _guess_ that the `DensityInversion` class works the same as most other CoTeDe QC tests, include it in catalog of tests in `qc.py`, and make it take a `QCCheckVar` argument and use the boilerplate init functions. Doing so allows the test to run and produce qualitatively reasonable (though still different from previous CoTeDe versions) results in AutoQC's test suite.

Let me know if this is completely wrong and there's another way to run the density inversion QC.