### PR TITLE
correctly extract profile envelope layers from old config formats

### DIFF
--- a/cotede/utils/config.py
+++ b/cotede/utils/config.py
@@ -209,7 +209,7 @@ def convert_pre_to_021(cfg):
         Should I confirm that cfg['profile_envelop'] is a list?
         """
         if "profile_envelop" in cfg:
-            cfg["profile_envelop"] = {"layers": cfg["profile_envelop"]}
+            cfg["profile_envelop"] = {"layers": cfg["profile_envelop"]["layers"]}
         return cfg
 
     output["variables"] = OrderedDict()


### PR DESCRIPTION
Hi @castelao - here is a possible fix for the final CoTeDe error coming up in AutoQC's testing, having to do with correcting the old config format to the new config format for `profile_envelop`. A couple of questions for you:

 - The change here definitely resolves the error in AutoQC, but is it generally true that the extra key is needed to convert the old config to the new config for this test? Or does this actually reflect something wrong with how AutoQC is constructing the config object for this test?
 - If this is indeed the correct change to make in CoTeDe, looking a few lines up in the file, there is a very similar piece of logic for `regional_range`. AutoQC doesn't use this so I don't know off the top of my head, but may be worth thinking about while our eyes are on this function. 