### PR TITLE
fix: profile_envelop config pre 0.21

### DIFF
--- a/cotede/__init__.py
+++ b/cotede/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'Guilherme Castelao'
 __email__ = 'guilherme@castelao.net'
-__version__ = '0.23.1'
+__version__ = '0.23.2'
 
 from cotede import qc
 from cotede.qc import ProfileQC, ProfileQCed

--- a/cotede/utils/config.py
+++ b/cotede/utils/config.py
@@ -208,7 +208,7 @@ def convert_pre_to_021(cfg):
         ----
         Should I confirm that cfg['profile_envelop'] is a list?
         """
-        if "profile_envelop" in cfg:
+        if ("profile_envelop" in cfg) and ("layers" not in cfg["profile_envelop"]):
             cfg["profile_envelop"] = {"layers": cfg["profile_envelop"]}
         return cfg
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.1
+current_version = 0.23.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('requirements.txt') as requirements_file:
 
 setup(
     name='cotede',
-    version='0.23.1',
+    version='0.23.2',
     description='Quality Control of Oceanographic Data',
     long_description=readme + '\n\n' + history,
     author='Guilherme Castelão',


### PR DESCRIPTION
The new standard expects layers in the item 'layer'. When converting from pre 0.21, only add a sub-item layers if necessary.