### PR TITLE
match fuzzy logic to updates from #48

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,4 +12,5 @@ Contributors
 
 * Luiz Irber <luiz.irber@gmail.com>  
 * @lidong74; Reported bug #37, outdated notebook on fuzzy logic.
-* @BillMills: PR #47, re-introduce Argo density inversion as inherited QCCheck.
+* @BillMills: - PR #47, re-introduce Argo density inversion as inherited QCCheck.
+              - PR #53, update fuzzy logic to handle edge-case NaNs rather than masks.

--- a/cotede/fuzzy/fuzzy_core.py
+++ b/cotede/fuzzy/fuzzy_core.py
@@ -40,7 +40,7 @@ def fuzzyfy(features, cfg):
                     "Missing %s in %s" % (m, cfg['features'][t])
 
             membership[m][t] = ma.masked_all_like(features[t])
-            ind = ~np.isnan(features[t])
+            ind = (~ma.getmaskarray(features[t]) & np.isfinite(features[t]))
             if m == 'low':
                 membership[m][t][ind] = zmf(
                         np.asanyarray(features[t])[ind], cfg['features'][t][m])

--- a/cotede/fuzzy/fuzzy_core.py
+++ b/cotede/fuzzy/fuzzy_core.py
@@ -40,7 +40,7 @@ def fuzzyfy(features, cfg):
                     "Missing %s in %s" % (m, cfg['features'][t])
 
             membership[m][t] = ma.masked_all_like(features[t])
-            ind = ~ma.getmaskarray(features[t])
+            ind = ~np.isnan(features[t])
             if m == 'low':
                 membership[m][t][ind] = zmf(
                         np.asanyarray(features[t])[ind], cfg['features'][t][m])


### PR DESCRIPTION
Hi @castelao - here's my best guess for how to resolve the problem I was mentioning in https://github.com/IQuOD/AutoQC/pull/261#issuecomment-744108074.

It seems that back in #48, you dropped the masks for things like spike and gradient results, and replaced masked values with NaNs. Problem is that fuzzy_core was using those masks to decide which levels in a profile to look at; this change tells fuzzy_core to look for NaNs instead of masks.

As always, you know best whether this actually makes sense, and if there are any other places in the code that might need a similar change. Running AutoQC over 1000 profiles with this change hacked into CoTeDe produces qualitatively reasonable looking results - instead of flagging all 1000 profiles as discussed in https://github.com/IQuOD/AutoQC/pull/261, I get:

```
                       NAME OF TEST   FAILS     TPR     FPR     TNR     FNR
                 CoTeDe_Morello2014     395   65.5%   20.9%   79.1%   34.5%
                 CoTeDe_fuzzy_logic     267   54.0%    7.2%   92.8%   46.0%
```

Which is in line (though again improved) compared to what we were seeing in earlier releases of CoTeDe.