### PR TITLE
fix: Explicit call to qctests.Morello2014

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Contributors
 * @lidong74; Reported bug #37, outdated notebook on fuzzy logic.
 * @BillMills: - PR #47, re-introduce Argo density inversion as inherited QCCheck.
               - PR #53, update fuzzy logic to handle edge-case NaNs rather than masks.
+              - Reported bug that resulted on PR #61.

--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -289,7 +289,7 @@ class ProfileQC(object):
                 self.features[v]['anomaly_detection'] = prob
 
         if 'morello2014' in cfg:
-            y = Morello2014(self.input, v, cfg['morello2014'], autoflag=True)
+            y = qctests.Morello2014(self.input, v, cfg['morello2014'], autoflag=True)
             if self.saveauxiliary:
                 for f in y.features.keys():
                     self.features[v][f] = y.features[f]

--- a/tests/qctests/test_qc_morello2014.py
+++ b/tests/qctests/test_qc_morello2014.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 
+from cotede.qc import ProfileQC
 from cotede.qctests import Morello2014
 from ..data import DummyData
 
@@ -44,3 +45,41 @@ def test_standard_dataset():
     # assert sorted(np.unique(pqc.flags['TEMP2']['morello2014'])) == [1]
     # assert sorted(np.unique(pqc.flags['PSAL']['morello2014'])) == [1, 2, 4]
     # assert sorted(np.unique(pqc.flags['PSAL2']['morello2014'])) == [1]
+
+
+def test_morello_from_profileqc():
+    """Run Morello2014 through ProfileQC
+
+    Notes
+    -----
+    - There is room to improve this and verify more stuff
+    """
+    cfg = {
+        "TEMP": {
+            "morello2014": {
+                "procedure": "Morello2014",
+                "output": {"low": None, "high": None},
+                "features": {
+                    "spike": {"weight": 1, "low": [0.07, 0.2], "high": [2, 6]},
+                    "woa_normbias": {"weight": 1, "low": [3, 4], "high": [5, 6]},
+                    "gradient": {"weight": 1, "low": [0.5, 1.5], "high": [3, 4]},
+                },
+            }
+        },
+        "PSAL": {
+            "morello2014": {
+                "output": {"low": None, "high": None},
+                "features": {
+                    "spike": {"weight": 1, "low": [0.05, 0.15], "high": [0.5, 0.9]},
+                    "woa_normbias": {"weight": 1, "low": [3, 4], "high": [5, 6]},
+                    "gradient": {"weight": 1, "low": [1, 2], "high": [3, 4]},
+                },
+            }
+        },
+    }
+
+    profile = DummyData()
+    pqc = ProfileQC(profile, cfg="morello2014")
+
+    for v in ("TEMP", "PSAL"):
+        assert "morello2014" in pqc.flags[v]


### PR DESCRIPTION
In preparation for the generic procedure, it is now called qctests.Morello2014 instead of importing everything from qctests.