### PR TITLE
fix: QCCheckVar require varname

### DIFF
--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -219,7 +219,7 @@ class ProfileQC(object):
             module_logger.warning(
                     "Sorry I'm not ready to evaluate frozen_profile()")
 
-        criteria = (c for c in cfg if ("procedure" in cfg[c]) and (cfg[c]["procedure"] in qctests.QCTESTS))
+        criteria = (c for c in cfg if (cfg[c] is not None) and ("procedure" in cfg[c]) and (cfg[c]["procedure"] in qctests.QCTESTS))
         for criterion in criteria:
             Procedure = qctests.catalog(cfg[criterion]["procedure"])
             if issubclass(Procedure, qctests.QCCheckVar):

--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -222,7 +222,10 @@ class ProfileQC(object):
         criteria = (c for c in cfg if ("procedure" in cfg[c]) and (cfg[c]["procedure"] in qctests.QCTESTS))
         for criterion in criteria:
             Procedure = qctests.catalog(cfg[criterion]["procedure"])
-            y = Procedure(self.input, varname=v, cfg=cfg[criterion], autoflag=True)
+            if issubclass(Procedure, qctests.QCCheckVar):
+                y = Procedure(self.input, varname=v, cfg=cfg[criterion], autoflag=True)
+            elif issubclass(Procedure, qctests.QCCheck):
+                y = Procedure(self.input, cfg=cfg[criterion], autoflag=True)
 
             if self.saveauxiliary:
                 for f in y.features.keys():

--- a/cotede/qctests/density_inversion.py
+++ b/cotede/qctests/density_inversion.py
@@ -84,6 +84,11 @@ class DensityInversion(QCCheck):
 
         flag = np.zeros(np.shape(self.data["TEMP"]), dtype="i1")
 
+        if ("densitystep" not in self.features) and not GSW_AVAILABLE:
+            module_logger.warning("Couldn't estimate density without GSW")
+            self.flags["density_inversion"] = flag
+            return
+
         feature = self.features["densitystep"]
         # Note the comparison is opposite of the usual (good if >=)
         flag[feature < threshold] = self.flag_bad

--- a/tests/qctests/test_qc_density_inversion.py
+++ b/tests/qctests/test_qc_density_inversion.py
@@ -5,6 +5,8 @@
 """
 
 import numpy as np
+
+from cotede.qc import ProfileQC
 from cotede.qctests import DensityInversion, densitystep
 from ..data import DummyData
 
@@ -83,6 +85,18 @@ def test_standard_dataset():
         assert np.allclose(y.features[f], features[f], equal_nan=True)
     for f in flags:
         assert np.allclose(y.flags[f], flags[f], equal_nan=True)
+
+
+def test_densityinversion_from_profileqc():
+    cfg = {
+        "TEMP": {"density_inversion": {"threshold": -0.03}},
+        "PSAL": {"density_inversion": {"threshold": -0.03}},
+    }
+    profile = DummyData()
+    pqc = ProfileQC(profile, cfg=cfg)
+
+    for v in ("TEMP", "PSAL"):
+        assert "density_inversion" in pqc.flags[v]
 
 
 # def test_input_types():

--- a/tests/qctests/test_qc_density_inversion.py
+++ b/tests/qctests/test_qc_density_inversion.py
@@ -88,6 +88,10 @@ def test_standard_dataset():
 
 
 def test_densityinversion_from_profileqc():
+    """Validate if ProfileQC can run DensityInversion
+
+    It requires GSW to estimate density if the density itself is not provided.
+    """
     cfg = {
         "TEMP": {"density_inversion": {"threshold": -0.03}},
         "PSAL": {"density_inversion": {"threshold": -0.03}},
@@ -97,6 +101,8 @@ def test_densityinversion_from_profileqc():
 
     for v in ("TEMP", "PSAL"):
         assert "density_inversion" in pqc.flags[v]
+        if not GSW_AVAILABLE:
+            assert (pqc.flags[v]["density_inversion"] == 0).all()
 
 
 # def test_input_types():


### PR DESCRIPTION
QCCheck doesn't accept varname while QCCheckVar requires a varname input. This is a temporary solution that will be replaced soon.