### PR TITLE
NetCDF memory leak workaround

### DIFF
--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -26,7 +26,7 @@ class ProfileQC(object):
     """
 
     def __init__(self, input, cfg=None, saveauxiliary=True, verbose=True,
-            attributes=None):
+            attributes=None, cars_db=None, woa_db=None, etopo_dbs=None):
         """A procedure to QC a hydrographic profile
 
         Parameters
@@ -58,7 +58,9 @@ class ProfileQC(object):
         keys(self): List of input contents
         """
         # self.logger = logging.getLogger(logger or 'cotede.ProfileQC')
-
+        self.__cars_db = cars_db
+        self.__woa_db = woa_db
+        self.__etopo_dbs = etopo_dbs
         try:
             self.name = input.filename
         except:
@@ -169,7 +171,7 @@ class ProfileQC(object):
             self.flags['common']['datetime_range'] = f
 
         if 'location_at_sea' in self.cfg['common']:
-            y = qctests.LocationAtSea(self.input, cfg['common']['location_at_sea'])
+            y = qctests.LocationAtSea(self.input, cfg['common']['location_at_sea'], etopo_dbs=self.__etopo_dbs)
 
             if self.saveauxiliary:
                 for f in y.features.keys():
@@ -294,11 +296,11 @@ class ProfileQC(object):
                     elif f == 'rate_of_change':
                         features['rate_of_change'] = qctests.rate_of_change(self.input[v])
                     elif (f == 'woa_normbias'):
-                        y = qctests.WOA_NormBias(self.input, v, {}, autoflag=False)
+                        y = qctests.WOA_NormBias(self.input, v, {}, autoflag=False, woa_db=self.__woa_db)
                         features['woa_normbias'] = \
                                 np.abs(y.features['woa_normbias'])
                     elif (f == 'cars_normbias'):
-                        y = qctests.CARS_NormBias(self.input, v, {}, autoflag=False)
+                        y = qctests.CARS_NormBias(self.input, v, {}, autoflag=False, cars_db=self.__cars_db)
                         features['cars_normbias'] = \
                                 np.abs(y.features['cars_normbias'])
                     else:
@@ -320,7 +322,7 @@ class ProfileQC(object):
                 self.flags[v][f] = y.flags[f]
 
         if "fuzzylogic" in  cfg:
-            y = qctests.FuzzyLogic(self.input, v, cfg["fuzzylogic"], autoflag=True)
+            y = qctests.FuzzyLogic(self.input, v, cfg["fuzzylogic"], autoflag=True, woa_db=self.__woa_db)
             if self.saveauxiliary:
                 for f in y.features.keys():
                     self.features[v][f] = y.features[f]

--- a/cotede/qc.py
+++ b/cotede/qc.py
@@ -245,9 +245,9 @@ class ProfileQC(object):
         for criterion in criteria:
             Procedure = qctests.catalog(cfg[criterion]["procedure"])
             if issubclass(Procedure, qctests.QCCheckVar):
-                y = Procedure(self.input, varname=v, cfg=cfg[criterion], autoflag=True)
+                y = Procedure(self.input, varname=v, cfg=cfg[criterion], autoflag=True, cars_db=self.__cars_db, woa_db=self.__woa_db, etopo_dbs=self.__etopo_dbs)
             elif issubclass(Procedure, qctests.QCCheck):
-                y = Procedure(self.input, cfg=cfg[criterion], autoflag=True)
+                y = Procedure(self.input, cfg=cfg[criterion], autoflag=True, cars_db=self.__cars_db, woa_db=self.__woa_db, etopo_dbs=self.__etopo_dbs)
 
             if self.saveauxiliary:
                 for f in y.features.keys():
@@ -314,7 +314,7 @@ class ProfileQC(object):
                 self.features[v]['anomaly_detection'] = prob
 
         if 'morello2014' in cfg:
-            y = qctests.Morello2014(self.input, v, cfg['morello2014'], autoflag=True)
+            y = qctests.Morello2014(self.input, v, cfg['morello2014'], autoflag=True, woa_db=self.__woa_db)
             if self.saveauxiliary:
                 for f in y.features.keys():
                     self.features[v][f] = y.features[f]

--- a/cotede/qctests/cars_normbias.py
+++ b/cotede/qctests/cars_normbias.py
@@ -61,7 +61,6 @@ def cars_normbias(data, varname, attrs=None, use_standard_error=False):
 
     depth = extract_depth(data)
 
-    db = CARS()
     # This must go away. This was a trick to handle Seabird CTDs, but
     # now that seabird is a different package it should be handled there.
     if isinstance(varname, str) and (varname[-1] == "2"):
@@ -88,10 +87,13 @@ def cars_normbias(data, varname, attrs=None, use_standard_error=False):
             raise IndexError
         elif not idx.all():
             valid_depth = depth[idx]
-    if mode == "track":
-        cars = db[vtype].track(var=cars_vars, doy=doy, depth=valid_depth, **kwargs)
-    else:
-        cars = db[vtype].extract(var=cars_vars, doy=doy, depth=valid_depth, **kwargs)
+
+    cars = None
+    with CARS() as db:
+        if mode == "track":
+            cars = db[vtype].track(var=cars_vars, doy=doy, depth=valid_depth, **kwargs)
+        else:
+            cars = db[vtype].extract(var=cars_vars, doy=doy, depth=valid_depth, **kwargs)
 
     if not np.all(depth == valid_depth):
         for v in cars.keys():

--- a/cotede/qctests/cars_normbias.py
+++ b/cotede/qctests/cars_normbias.py
@@ -163,7 +163,7 @@ class CARS_NormBias(QCCheckVar):
     # 3 is the possible minimum to estimate the std, but I shold use higher.
     min_samples = 3
 
-    def __init__(self, data, varname, cfg=None, autoflag=True, cars_db=None):
+    def __init__(self, data, varname, cfg=None, autoflag=True, cars_db=None, woa_db=None, etopo_dbs=None):
         try:
             self.use_standard_error = cfg["use_standard_error"]
         except (KeyError, TypeError):
@@ -172,13 +172,12 @@ class CARS_NormBias(QCCheckVar):
             self.min_samples = cfg["min_samples"]
         except (KeyError, TypeError):
             module_logger.debug("min_samples undefined. Using default value")
-        self.__cars_db = cars_db
-        super().__init__(data, varname, cfg, autoflag)
+        super().__init__(data, varname, cfg, autoflag, cars_db=cars_db, woa_db=woa_db, etopo_dbs=etopo_dbs)
 
 
     def set_features(self):
         try:
-            self.features = cars_normbias(self.data, self.varname, self.attrs, cars_db=self.__cars_db)
+            self.features = cars_normbias(self.data, self.varname, self.attrs, cars_db=self._cars_db)
         except LookupError:
             self.features = {}
 

--- a/cotede/qctests/core.py
+++ b/cotede/qctests/core.py
@@ -19,8 +19,11 @@ class QCCheck(object):
     flag_good = 1
     flag_bad = 4
 
-    def __init__(self, data, *, cfg=None, autoflag=True, attrs=None):
+    def __init__(self, data, *, cfg=None, autoflag=True, attrs=None, cars_db=None, woa_db=None, etopo_dbs=None):
         self.data = data
+        self._cars_db = cars_db
+        self._woa_db = woa_db
+        self._etopo_dbs = etopo_dbs
         if (cfg is not None):
             self.cfg = cfg
         elif not hasattr(self, 'cfg'):
@@ -70,6 +73,6 @@ class QCCheckVar(QCCheck):
     """Template for a QC check of a specific variable
     """
 
-    def __init__(self, data, varname, cfg=None, autoflag=True, attrs=None):
+    def __init__(self, data, varname, cfg=None, autoflag=True, attrs=None, cars_db=None, woa_db=None, etopo_dbs=None):
         self.varname = varname
-        super().__init__(data=data, cfg=cfg, autoflag=autoflag, attrs=attrs)
+        super().__init__(data=data, cfg=cfg, autoflag=autoflag, attrs=attrs, cars_db=cars_db, woa_db=woa_db, etopo_dbs=etopo_dbs)

--- a/cotede/qctests/density_inversion.py
+++ b/cotede/qctests/density_inversion.py
@@ -49,12 +49,12 @@ def densitystep(SA, t, p, auto_rotate=False):
 
 
 class DensityInversion(QCCheck):
-    def __init__(self, data, cfg, autoflag=True):
+    def __init__(self, data, cfg, autoflag=True, cars_db=None, woa_db=None, etopo_dbs=None):
         assert "TEMP" in data.keys(), "Missing TEMP"
         assert "PSAL" in data.keys(), "Missing PSAL"
         assert "PRES" in data.keys(), "Missing PRES"
 
-        super().__init__(data=data, cfg=cfg, autoflag=autoflag)
+        super().__init__(data=data, cfg=cfg, autoflag=autoflag, cars_db=cars_db, woa_db=woa_db, etopo_dbs=etopo_dbs)
 
     def set_features(self):
         if not GSW_AVAILABLE:

--- a/cotede/qctests/fuzzylogic.py
+++ b/cotede/qctests/fuzzylogic.py
@@ -44,19 +44,14 @@ def fuzzylogic(features, cfg, require="all"):
 
 
 class FuzzyLogic(QCCheckVar):
-    def __init__(self, data, varname, cfg=None, autoflag=True, attrs=None, woa_db=None):
-        self.__woa_db = woa_db
-        super().__init__(data, varname, cfg=cfg, autoflag=autoflag, attrs=attrs)
-
-
     def set_features(self):
         self.features = {}
         for v in [f for f in self.cfg["features"] if f not in self.features]:
             if v == "woa_bias":
-                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self.__woa_db)
+                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self._woa_db)
                 self.features[v] = woa_comparison["woa_bias"]
             elif v == "woa_normbias":
-                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self.__woa_db)
+                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self._woa_db)
                 self.features[v] = woa_comparison["woa_normbias"]
             elif v == "spike":
                 self.features[v] = spike(self.data[self.varname])

--- a/cotede/qctests/fuzzylogic.py
+++ b/cotede/qctests/fuzzylogic.py
@@ -44,14 +44,19 @@ def fuzzylogic(features, cfg, require="all"):
 
 
 class FuzzyLogic(QCCheckVar):
+    def __init__(self, data, varname, cfg=None, autoflag=True, attrs=None, woa_db=None):
+        self.__woa_db = woa_db
+        super().__init__(data, varname, cfg=cfg, autoflag=autoflag, attrs=attrs)
+
+
     def set_features(self):
         self.features = {}
         for v in [f for f in self.cfg["features"] if f not in self.features]:
             if v == "woa_bias":
-                woa_comparison = woa_normbias(self.data, self.varname, self.attrs)
+                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self.__woa_db)
                 self.features[v] = woa_comparison["woa_bias"]
             elif v == "woa_normbias":
-                woa_comparison = woa_normbias(self.data, self.varname, self.attrs)
+                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self.__woa_db)
                 self.features[v] = woa_comparison["woa_normbias"]
             elif v == "spike":
                 self.features[v] = spike(self.data[self.varname])

--- a/cotede/qctests/location_at_sea.py
+++ b/cotede/qctests/location_at_sea.py
@@ -82,10 +82,11 @@ def location_at_sea(data, cfg=None):
         return flag_bad
 
     try:
-        ETOPO = oceansdb.ETOPO()
-        etopo = ETOPO["topography"].extract(
-            var="height", lat=data.attrs["LATITUDE"], lon=data.attrs["LONGITUDE"]
-        )
+        etopo = None
+        with oceansdb.ETOPO() as ETOPO:
+            etopo = ETOPO["topography"].extract(
+                var="height", lat=data.attrs["LATITUDE"], lon=data.attrs["LONGITUDE"]
+            )
         h = etopo["height"]
 
         flag = np.zeros(h.shape, dtype="i1")
@@ -105,10 +106,9 @@ def get_bathymetry(lat, lon, resolution="5min"):
     """
     assert np.shape(lat) == np.shape(lon), "Lat & Lon shape mismatch"
 
-    db = oceansdb.ETOPO(resolution=resolution)
-
-    etopo = db["topography"].track(var="height", lat=lat, lon=lon)
-    return {"bathymetry": -etopo["height"].astype("i")}
+    with oceansdb.ETOPO(resolution=resolution) as db:
+        etopo = db["topography"].track(var="height", lat=lat, lon=lon)
+        return {"bathymetry": -etopo["height"].astype("i")}
 
 
 class LocationAtSea(QCCheck):

--- a/cotede/qctests/location_at_sea.py
+++ b/cotede/qctests/location_at_sea.py
@@ -109,7 +109,7 @@ def get_bathymetry(lat, lon, resolution="5min", etopo_dbs=None):
     assert np.shape(lat) == np.shape(lon), "Lat & Lon shape mismatch"
 
     etopo = None
-    if etopo_dbs is None or not etopo_dbs.get(resolution):
+    if etopo_dbs is None:
         with oceansdb.ETOPO(resolution=resolution) as db:
             etopo = _get_etopo(db, lat, lon)
     else:

--- a/cotede/qctests/location_at_sea.py
+++ b/cotede/qctests/location_at_sea.py
@@ -123,7 +123,7 @@ class LocationAtSea(QCCheck):
     resolution = "5min"
     threshold = 0
 
-    def __init__(self, data, cfg=None, attrs=None, etopo_dbs=None):
+    def __init__(self, data, cfg=None, attrs=None, cars_db=None, woa_db=None, etopo_dbs=None):
         if cfg is None:
             cfg = {}
 
@@ -131,8 +131,7 @@ class LocationAtSea(QCCheck):
             cfg["threshold"] = self.threshold
         if "resolution" not in cfg:
             cfg["resolution"] = self.resolution
-        self.__etopo_dbs = etopo_dbs
-        super().__init__(data, cfg=cfg, attrs=attrs)
+        super().__init__(data, cfg=cfg, attrs=attrs, cars_db=cars_db, woa_db=woa_db, etopo_dbs=etopo_dbs)
 
     def set_features(self):
         if not OCEANSDB_AVAILABLE:
@@ -147,7 +146,7 @@ class LocationAtSea(QCCheck):
             return
 
         try:
-            self.features = get_bathymetry(lat=lat, lon=lon, etopo_dbs=self.__etopo_dbs)
+            self.features = get_bathymetry(lat=lat, lon=lon, etopo_dbs=self._etopo_dbs)
             # idx = np.isfinite(lat) & np.isfinite(lon)
             # self.features = get_bathymetry(lat=lat[idx], lon=lon[idx])
         except:

--- a/cotede/qctests/morello2014.py
+++ b/cotede/qctests/morello2014.py
@@ -62,10 +62,10 @@ class Morello2014(QCCheckVar):
         self.features = {}
         for v in [f for f in self.cfg["features"] if f not in self.features]:
             if v == "woa_bias":
-                woa_comparison = woa_normbias(self.data, self.varname, self.attrs)
+                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self._woa_db)
                 self.features[v] = woa_comparison["woa_bias"]
             elif v == "woa_normbias":
-                woa_comparison = woa_normbias(self.data, self.varname, self.attrs)
+                woa_comparison = woa_normbias(self.data, self.varname, self.attrs, woa_db=self._woa_db)
                 self.features[v] = woa_comparison["woa_normbias"]
             elif v == "spike":
                 self.features[v] = spike(self.data[self.varname])

--- a/cotede/qctests/woa_normbias.py
+++ b/cotede/qctests/woa_normbias.py
@@ -177,7 +177,7 @@ class WOA_NormBias(QCCheckVar):
     # 3 is the possible minimum to estimate the std, but I shold use higher.
     min_samples = 3
 
-    def __init__(self, data, varname, cfg=None, autoflag=True, woa_db=None):
+    def __init__(self, data, varname, cfg=None, autoflag=True, cars_db=None, woa_db=None, etopo_dbs=None):
         try:
             self.use_standard_error = cfg["use_standard_error"]
         except (KeyError, TypeError):
@@ -186,13 +186,12 @@ class WOA_NormBias(QCCheckVar):
             self.min_samples = cfg["min_samples"]
         except (KeyError, TypeError):
             module_logger.debug("min_samples undefined. Using default value")
-        self.__woa_db = woa_db
-        super().__init__(data, varname, cfg, autoflag)
+        super().__init__(data, varname, cfg, autoflag, cars_db=cars_db, woa_db=woa_db, etopo_dbs=etopo_dbs)
 
 
     def set_features(self):
         try:
-            self.features = woa_normbias(self.data, self.varname, self.attrs, woa_db=self.__woa_db)
+            self.features = woa_normbias(self.data, self.varname, self.attrs, woa_db=self._woa_db)
         except LookupError:
             self.features = {}
 

--- a/cotede/qctests/woa_normbias.py
+++ b/cotede/qctests/woa_normbias.py
@@ -71,7 +71,6 @@ def woa_normbias(data, varname, attrs=None, use_standard_error=False):
 
     depth = extract_depth(data)
 
-    db = WOA()
     # This must go away. This was a trick to handle Seabird CTDs, but
     # now that seabird is a different package it should be handled there.
     if isinstance(varname, str) and (varname[-1] == "2"):
@@ -96,10 +95,13 @@ def woa_normbias(data, varname, attrs=None, use_standard_error=False):
             raise IndexError
         elif not idx.all():
             valid_depth = depth[idx]
-    if mode == "track":
-        woa = db[vtype].track(var=woa_vars, doy=doy, depth=valid_depth, **kwargs)
-    else:
-        woa = db[vtype].extract(var=woa_vars, doy=doy, depth=valid_depth, **kwargs)
+
+    woa = None
+    with WOA() as db:
+        if mode == "track":
+            woa = db[vtype].track(var=woa_vars, doy=doy, depth=valid_depth, **kwargs)
+        else:
+            woa = db[vtype].extract(var=woa_vars, doy=doy, depth=valid_depth, **kwargs)
 
     if not np.all(depth == valid_depth):
         for v in woa.keys():

--- a/cotede/utils/config.py
+++ b/cotede/utils/config.py
@@ -299,7 +299,7 @@ def convert_021_to_022(cfg):
     is now explicit so that the user has the freedom to choose alternatives.
     """
     assert ("revision" in cfg) and (cfg["revision"] == "0.21")
-    cfg["revision"] = 0.22
+    cfg["revision"] = "0.22"
 
     for v in cfg["variables"]:
         procedures = [f for f in cfg["variables"][v] if f in ("fuzzylogic", "morello2014")]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.16
 scipy>=0.18.0
-oceansdb>=0.8.13
+oceansdb>=0.8.15

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     zip_safe=False,
     extras_require = {
         'GSW': ["gsw>=3.0.6"],
-        'OceansDB': ["oceansdb>=0.8.13"],
+        'OceansDB': ["oceansdb>=0.8.15"],
         'manualqc': ["matplotlib"],
         'regional': ["Shapely>=1.6.4"]
     }


### PR DESCRIPTION
@castelao  This is a draft pull request that is built upon PR#66 that I am submitting for review if there is anything that you feel will be useful in CoTeDe.  Don't feel obligated to accept it.  This is a workaround for https://github.com/Unidata/netcdf4-python/issues/1021 / https://github.com/Unidata/netcdf-c/issues/2626.  Theses changes allow for oceandb instances to be passed in, preventing them from being opened and closed repeatedly, which eventually exhausts all the available memory.  